### PR TITLE
Correct handling of go test -v output over multiple packages.

### DIFF
--- a/data/gotest.out
+++ b/data/gotest.out
@@ -13,4 +13,5 @@ exit status 1
 FAIL	_/home/miki/Projects/goroot/src/xunit	0.004s
 === RUN TestAdd
 --- PASS: TestAdd (0.00 seconds)
+PASS
 ok  	_/home/miki/Projects/goroot/src/anotherTest	0.000s

--- a/go2xunit.go
+++ b/go2xunit.go
@@ -145,7 +145,7 @@ func gt_Parse(rd io.Reader) ([]*Suite, error) {
 			continue
 		}
 
-		if is_exit(line) || (line == "FAIL") {
+		if is_exit(line) || line == "FAIL" || line == "PASS" {
 			continue
 		}
 


### PR DESCRIPTION
Two passing suites in a row resulted in this error:

```
    --- FAIL: Test_parseOutput (0.00 seconds)
        go2xunit_test.go:40: error loading data/gotest.out - orphan output: PASS
```

This commit adds the `PASS` line that `go test -v` emits to the test output and updates the parsing loop to account for it.
