### PR TITLE
Ensuring that an error message in the last test in a suite is correctly parsed

### DIFF
--- a/data/gotest-multierror.out
+++ b/data/gotest-multierror.out
@@ -1,0 +1,9 @@
+=== RUN TestError1
+--- FAIL: TestError1 (0.00 seconds)
+	main_test.go:10: something went wrong
+=== RUN TestError2
+--- FAIL: TestError2 (0.00 seconds)
+	main_test.go:14: something new went wrong
+FAIL
+exit status 1
+FAIL	skeleton	0.047s

--- a/go2xunit_test.go
+++ b/go2xunit_test.go
@@ -203,3 +203,37 @@ func Test_Multi(t *testing.T) {
 		t.Fatalf("bad number of suites. expected %d got %d", count, len(suites))
 	}
 }
+
+func Test_ThatMessageIsParsedCorrectly_WhenThereIsAnErrorWithinTheLastTestInSuite(t *testing.T) {
+	filename := "data/gotest-multierror.out"
+	suites, err := loadGotest(filename, t)
+	if err != nil {
+		t.Fatalf("error loading %s - %s", filename, err)
+	}
+
+	count := 1
+	if len(suites) != count {
+		t.Fatalf("bad number of suites. expected %d got %d", count, len(suites))
+	}
+
+	suite := suites[0]
+
+	if len(suite.Tests) != 2 {
+		t.Fatalf("bad number of tests. expected %d got %d", 2, len(suite.Tests))
+	}
+
+	expectedMessages := []string{
+		"\tmain_test.go:10: something went wrong",
+		"\tmain_test.go:14: something new went wrong",
+	}
+
+	for i, test := range suite.Tests {
+		if test.Message != expectedMessages[i] {
+			t.Errorf(
+				"test %v message does not match expected result:\n\tGot: \"%v\"\n\tExpected: \"%v\"\n",
+				i,
+				test.Message,
+				expectedMessages[i])
+		}
+	}
+}


### PR DESCRIPTION
I ran into this issue while testing out CI systems - one of the tracebacks from my test errors was going missing. Much like we collect the output and add it to the last test when we encounter a new test, we must do the same at the end of a suite.

Using a closure was the easiest way to reuse the code.
