### PR TITLE
Patch to deal with Parallel tests and _test.go files with examples

### DIFF
--- a/data/gotest-notests.out
+++ b/data/gotest-notests.out
@@ -1,0 +1,3 @@
+testing: warning: no tests to run
+PASS
+ok  	example	0.002s

--- a/data/gotest-parallel.out
+++ b/data/gotest-parallel.out
@@ -1,0 +1,12 @@
+=== RUN A
+=== RUN B
+=== RUN C
+=== RUN D
+=== RUN E
+--- PASS: A (0.00 seconds)
+--- PASS: B (0.00 seconds)
+--- PASS: C (0.00 seconds)
+--- PASS: D (0.00 seconds)
+--- PASS: E (0.00 seconds)
+PASS
+ok  	example	0.004s

--- a/go2xunit.go
+++ b/go2xunit.go
@@ -32,6 +32,9 @@ const (
 	// ?       alipay  [no test files]
 	gt_noFiles = "^\\?.*\\[no test files\\]$"
 
+	// testing: warning: no tests to run
+	gt_noTests = "^testing: warning: no tests to run$"
+
 	// gocheck regular expressions
 
 	// START: mmath_test.go:16: MySuite.TestAdd
@@ -90,10 +93,11 @@ func gt_Parse(rd io.Reader) ([]*Suite, error) {
 	find_end := regexp.MustCompile(gt_endRE).FindStringSubmatch
 	find_suite := regexp.MustCompile(gt_suiteRE).FindStringSubmatch
 	is_nofiles := regexp.MustCompile(gt_noFiles).MatchString
+	is_notests := regexp.MustCompile(gt_noTests).MatchString
 	is_exit := regexp.MustCompile("^exit status -?\\d+").MatchString
 
 	suites := []*Suite{}
-	var curTest *Test
+	testsInSuite := map[string]*Test{}
 	var curSuite *Suite
 	var out []string
 
@@ -116,14 +120,16 @@ func gt_Parse(rd io.Reader) ([]*Suite, error) {
 		// TODO: Only ouside a suite/test, report as empty suite?
 		if is_nofiles(line) {
 			continue
+		} else if is_notests(line) {
+			if curSuite == nil {
+				curSuite = &Suite{}
+			}
+			continue
 		}
 
 		tokens := find_start(line)
 		if tokens != nil {
-			if curTest != nil {
-				return nil, fmt.Errorf("%d: test in middle of other", lnum)
-			}
-			curTest = &Test{
+			testsInSuite[tokens[1]] = &Test{
 				Name: tokens[1],
 			}
 
@@ -135,11 +141,15 @@ func gt_Parse(rd io.Reader) ([]*Suite, error) {
 
 		tokens = find_end(line)
 		if tokens != nil {
-			if curTest == nil {
-				return nil, fmt.Errorf("%d: orphan end test", lnum)
-			}
-			if tokens[2] != curTest.Name {
-				return nil, fmt.Errorf("%d: name mismatch", lnum)
+			name := tokens[2]
+			curTest, exists := testsInSuite[name]
+
+			if !exists {
+				return nil, fmt.Errorf(
+					"Found test result for test that didn't start running (line %v): %s",
+					lnum,
+					line,
+				)
 			}
 
 			curTest.Failed = (tokens[1] == "FAIL")
@@ -166,6 +176,7 @@ func gt_Parse(rd io.Reader) ([]*Suite, error) {
 			}
 			suites = append(suites, curSuite)
 			curSuite = nil
+			testsInSuite = map[string]*Test{}
 
 			continue
 		}

--- a/go2xunit_test.go
+++ b/go2xunit_test.go
@@ -237,3 +237,39 @@ func Test_ThatMessageIsParsedCorrectly_WhenThereIsAnErrorWithinTheLastTestInSuit
 		}
 	}
 }
+
+func Test_Parallel(t *testing.T) {
+	filename := "data/gotest-parallel.out"
+	suites, err := loadGotest(filename, t)
+	if err != nil {
+		t.Fatalf("error loading %s - %s", filename, err)
+	}
+
+	count := 1
+	if len(suites) != count {
+		t.Fatalf("bad number of suites. expected %d got %d", count, len(suites))
+	}
+	if suites[0].Count() != 5 {
+		t.Errorf(
+			"Wrong number of tests in suite, expected %v, for %v",
+			5,
+			suites[0].Count())
+	}
+}
+
+func Test_NoTests(t *testing.T) {
+	filename := "data/gotest-notests.out"
+	suites, err := loadGotest(filename, t)
+	if err != nil {
+		t.Fatalf("error loading %s - %s", filename, err)
+	}
+
+	count := 1
+	if len(suites) != count {
+		t.Fatalf(
+			"bad number of suites. expected %d got %d",
+			count,
+			len(suites),
+		)
+	}
+}


### PR DESCRIPTION
Apologies for doing this as a pull request in Github again, but I don't have a Bitbucket account and this lets me make any changes you need to the fixes if required.

This patch should allow for packages that have _test.go files for examples, but no tests, and where t.Parallel() is used, causing out of order PASS / FAIL. The combination of these two fixes allowed me to run using <package>/... on some code that I have, and on some tests where I was experimenting on some running tests on some purely functional code.

All tests were passing locally, but I had to remove some checks that you had in there, so it's possible that there needs to be a test for an edge case that they were covering that's still valid.
