### PR TITLE
Fixed running examples.

### DIFF
--- a/go2xunit.go
+++ b/go2xunit.go
@@ -18,7 +18,7 @@ const (
 	// gotest regular expressions
 
 	// === RUN TestAdd
-	gt_startRE = "^=== RUN ([a-zA-Z_][[:word:]]*)"
+	gt_startRE = "^=== RUN:? ([a-zA-Z_][[:word:]]*)"
 
 	// --- PASS: TestSub (0.00 seconds)
 	// --- FAIL: TestSubFail (0.00 seconds)


### PR DESCRIPTION
For some reason, examples have a colon after "RUN".

```
go test -v
=== RUN TestXOR
--- PASS: TestXOR (0.00 seconds)
=== RUN TestCBCEncrypterAES
--- PASS: TestCBCEncrypterAES (0.00 seconds)
=== RUN TestCBCDecrypterAES
--- PASS: TestCBCDecrypterAES (0.00 seconds)
=== RUN TestCFB
--- PASS: TestCFB (0.00 seconds)
=== RUN TestCryptBlocks
--- PASS: TestCryptBlocks (0.00 seconds)
=== RUN TestCTR_AES
--- PASS: TestCTR_AES (0.00 seconds)
=== RUN TestAESGCM
--- PASS: TestAESGCM (0.00 seconds)
=== RUN TestOFB
--- PASS: TestOFB (0.00 seconds)
=== RUN: ExampleNewCBCDecrypter
--- PASS: ExampleNewCBCDecrypter (9.93us)
=== RUN: ExampleNewCFBDecrypter
--- PASS: ExampleNewCFBDecrypter (7.411us)
=== RUN: ExampleNewCTR
--- PASS: ExampleNewCTR (11.72us)
=== RUN: ExampleNewOFB
--- PASS: ExampleNewOFB (16.021us)
PASS
ok      github.com/qpingu/crypto/cipher 0.003s
```
