### PR TITLE
Ignore test name suffix generated by GOMAXPROCS

### DIFF
--- a/go2xunit.go
+++ b/go2xunit.go
@@ -18,12 +18,12 @@ const (
 	// gotest regular expressions
 
 	// === RUN TestAdd
-	gt_startRE = "^=== RUN:? ([a-zA-Z_][^[:space:]]*)"
+	gt_startRE = "^=== RUN:? ([a-zA-Z_][[:word:]]*)(?:-\\d+)?"
 
 	// --- PASS: TestSub (0.00 seconds)
 	// --- FAIL: TestSubFail (0.00 seconds)
 	// --- SKIP: TestSubSkip (0.00 seconds)
-	gt_endRE = "^--- (PASS|FAIL|SKIP): ([a-zA-Z_][^[:space:]]*) \\((\\d+.\\d+)"
+	gt_endRE = "^--- (PASS|FAIL|SKIP): ([a-zA-Z_][[:word:]]*)(?:-\\d+)? \\((\\d+.\\d+)"
 
 	// FAIL	_/home/miki/Projects/goroot/src/xunit	0.004s
 	// ok  	_/home/miki/Projects/goroot/src/anotherTest	0.000s

--- a/go2xunit_test.go
+++ b/go2xunit_test.go
@@ -321,8 +321,24 @@ func Test_parseBuildFailed(t *testing.T) {
 }
 
 func Test_nameWithNum(t *testing.T) {
-	_, err := loadGotest("data/gotest-num.out", t)
+	suites, err := loadGotest("data/gotest-num.out", t)
 	if err != nil {
 		t.Fatalf("didn't parse name with number")
+	}
+
+	count := 1
+	if len(suites) != count {
+		t.Fatalf("bad number of suites. expected %d got %d", count, len(suites))
+	}
+
+	suite := suites[0]
+	if len(suite.Tests) != 1 {
+		t.Fatalf("bad number of tests. expected %d got %d", 1, len(suite.Tests))
+	}
+
+	test := suite.Tests[0]
+	name := "TestBasic"
+	if test.Name != name {
+		t.Fatalf("bad test name %s != %s", test.Name, name)
 	}
 }


### PR DESCRIPTION
Hi, In issue #14 and 1daba18ac3 you changed the parser to accept test name that suffixed with `-N` and now the parser generates the report with suffix `-N`.
However these suffix is usually generated by `go test` with explicit GOMAXPROCS env val.

For example, `GOMAXPROCS=3 go test -v|go2xunit` will generate the below.

```
...
<testcase classname="github.com/tebeka/go2xunit" name="Test_nameWithNum-3" time="0.00">
...
```

Thus, in most situations, `-N` is NOT a part of ideal test name and noisy.
So in this request, I want to change to handle these suffix as an ignored part of  regex, not the name.
