### PR TITLE
Ignore SetUpTest and TearDownTest, treat MISS as SKIP for GoCheck

### DIFF
--- a/data/gocheck-setup-miss.out
+++ b/data/gocheck-setup-miss.out
@@ -1,0 +1,18 @@
+=== RUN Test
+START: foobar_test.go:17: FoobarSuite.SetUpSuite
+foobar_test.go:19:
+    c.Assert(err, gc.IsNil)
+... value *os.PathError = &os.PathError{Op:"stat", Path:"testdata/regexes.yaml", Err:0x2} ("stat testdata/regexes.yaml: no such file or directory")
+
+FAIL: foobar_test.go:17: FoobarSuite.SetUpSuite
+
+START: foobar_test.go:79: FoobarSuite.TestFrob
+MISS: foobar_test.go:79: FoobarSuite.TestFrob
+
+START: foobar_test.go:102: FoobarSuite.TestThing
+MISS: foobar_test.go:102: FoobarSuite.TestThing
+
+OOPS: 82 passed, 1 FAILED, 2 MISSED
+--- FAIL: Test (2.37s)
+FAIL
+FAIL    github.com/you/yourproject/foobar   2.383s

--- a/go2xunit.go
+++ b/go2xunit.go
@@ -46,7 +46,7 @@ const (
 
 	// PASS: mmath_test.go:16: MySuite.TestAdd	0.000s
 	// FAIL: mmath_test.go:35: MySuite.TestDiv
-	gc_endRE = "(PASS|FAIL|SKIP|PANIC): [^:]+:[^:]+: ([A-Za-z_][[:word:]]*).([A-Za-z_][[:word:]]*)[[:space:]]?([0-9]+.[0-9]+)?"
+	gc_endRE = "(PASS|FAIL|SKIP|PANIC|MISS): [^:]+:[^:]+: ([A-Za-z_][[:word:]]*).([A-Za-z_][[:word:]]*)[[:space:]]?([0-9]+.[0-9]+)?"
 
 	// FAIL	go2xunit/demo-gocheck	0.008s
 	// ok  	go2xunit/demo-gocheck	0.008s
@@ -317,6 +317,9 @@ func gc_Parse(rd io.Reader) ([]*Suite, error) {
 
 		tokens := find_start(line)
 		if len(tokens) > 0 {
+			if tokens[2] == "SetUpTest" || tokens[2] == "TearDownTest" {
+				continue
+			}
 			if testName != "" {
 				return nil, fmt.Errorf("%d: start in middle\n", lnum)
 			}
@@ -328,6 +331,9 @@ func gc_Parse(rd io.Reader) ([]*Suite, error) {
 
 		tokens = find_end(line)
 		if len(tokens) > 0 {
+			if tokens[3] == "SetUpTest" || tokens[3] == "TearDownTest" {
+				continue
+			}
 			if testName == "" {
 				return nil, fmt.Errorf("%d: orphan end", lnum)
 			}
@@ -339,7 +345,7 @@ func gc_Parse(rd io.Reader) ([]*Suite, error) {
 			test.Time = tokens[4]
 			test.Failed = (tokens[1] == "FAIL") || (tokens[1] == "PANIC")
 			test.Passed = (tokens[1] == "PASS")
-			test.Skipped = (tokens[1] == "SKIP")
+			test.Skipped = (tokens[1] == "SKIP" || tokens[1] == "MISS")
 
 			if suite == nil || suite.Name != suiteName {
 				suite = &Suite{Name: suiteName}

--- a/io_test.go
+++ b/io_test.go
@@ -16,6 +16,7 @@ var goCheckFiles []string = []string{
 	"gocheck-panic.out",
 	"gocheck-nofiles.out",
 	"gocheck-empty.out",
+	"gocheck-setup-miss.out",
 }
 
 var goTestFiles []string = []string{

--- a/xml/xunit.net/gocheck-setup-miss.out.xml
+++ b/xml/xunit.net/gocheck-setup-miss.out.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly name="FoobarSuite"
+          run-date="2015-06-05" run-time="18:34:41"
+          configFile="none"
+          time="2.383"
+          total="3"
+          passed="0"
+          failed="1"
+          skipped="2"
+          environment="n/a"
+          test-framework="golang">
+
+    <class time="2.383" name="FoobarSuite"
+  	     total="3"
+  	     passed="0"
+  	     failed="1"
+  	     skipped="2">
+
+        <test name="SetUpSuite"
+          type="test"
+          method="SetUpSuite"
+          result="Fail"
+          time="">
+          <failure exception-type="go.error">
+             <message><![CDATA[foobar_test.go:19:
+    c.Assert(err, gc.IsNil)
+... value *os.PathError = &os.PathError{Op:"stat", Path:"testdata/regexes.yaml", Err:0x2} ("stat testdata/regexes.yaml: no such file or directory")
+]]></message>
+      	  </failure>
+      	</test>
+
+        <test name="TestFrob"
+          type="test"
+          method="TestFrob"
+          result="Skip"
+          time="">
+        </test>
+
+        <test name="TestThing"
+          type="test"
+          method="TestThing"
+          result="Skip"
+          time="">
+        </test>
+
+    </class>
+
+</assembly>

--- a/xml/xunit/gocheck-setup-miss.out.xml
+++ b/xml/xunit/gocheck-setup-miss.out.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+  <testsuite name="FoobarSuite" tests="3" errors="0" failures="1" skip="2">
+    <testcase classname="FoobarSuite" name="SetUpSuite" time="">
+
+      <failure type="go.error" message="error">
+        <![CDATA[foobar_test.go:19:
+    c.Assert(err, gc.IsNil)
+... value *os.PathError = &os.PathError{Op:"stat", Path:"testdata/regexes.yaml", Err:0x2} ("stat testdata/regexes.yaml: no such file or directory")
+]]>
+      </failure>    </testcase>
+    <testcase classname="FoobarSuite" name="TestFrob" time="">
+      <skipped/> 
+    </testcase>
+    <testcase classname="FoobarSuite" name="TestThing" time="">
+      <skipped/> 
+    </testcase>
+  </testsuite>


### PR DESCRIPTION
When {SetUp,TearDown}{Suite,Test} are used in a gocheck test suite, it
produces -gocheck.vv output as follows:

START: redis_service_test.go:78: RedisSuite.TestRedisClientNoServers
START: redis_service_test.go:22: RedisSuite.SetUpTest
PASS: redis_service_test.go:22: RedisSuite.SetUpTest    0.000s
PASS: redis_service_test.go:78: RedisSuite.TestRedisClientNoServers 0.000s

The SetUpTest functions run after the START of the real test that is being
run, which confuses go2xunit.
    
Fix this by simply ignoring SetUpTest and TearDownTest functions when
converting test output to xunit.

Additionally, treat MISS as a SKIP for the GoCheck parser.
    
Add a test case for both of these.
