### PR TITLE
Support gotest runners (like bazel) that don't print a per-suite summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/go2xunit

--- a/cmdline.go
+++ b/cmdline.go
@@ -16,6 +16,7 @@ var args struct {
 	xunitnetOut bool
 	isGocheck   bool
 	failOnRace  bool
+	suitePrefix string
 }
 
 func init() {
@@ -29,6 +30,8 @@ func init() {
 	flag.BoolVar(&args.isGocheck, "gocheck", false, "parse gocheck output")
 	flag.BoolVar(&args.failOnRace, "fail-on-race", false,
 		"mark test as failing if it exposes a data race")
+	flag.StringVar(&args.suitePrefix, "suite-name-prefix", "",
+		"prefix to include before all suite names")
 
 	flag.Parse()
 }

--- a/data/gotest-nosummary.out
+++ b/data/gotest-nosummary.out
@@ -1,0 +1,7 @@
+=== RUN   TestMeaning
+--- PASS: TestMeaning (0.00s)
+=== RUN   TestAddTwoNumbers
+2 + 3 = 5
+--- FAIL: TestAddTwoNumbers (0.00s)
+        lib_test.go:30: failing just because
+FAIL

--- a/go2xunit.go
+++ b/go2xunit.go
@@ -163,7 +163,7 @@ func main() {
 		testTime = stat.ModTime()
 	}
 
-	var parse func(rd io.Reader) ([]*Suite, error)
+	var parse func(rd io.Reader, suiteName string) ([]*Suite, error)
 
 	if args.isGocheck {
 		parse = gcParse
@@ -171,7 +171,7 @@ func main() {
 		parse = gtParse
 	}
 
-	suites, err := parse(input)
+	suites, err := parse(input, args.suitePrefix)
 	if err != nil {
 		log.Fatalf("error: %s", err)
 	}

--- a/go2xunit_test.go
+++ b/go2xunit_test.go
@@ -471,3 +471,29 @@ func Test_TestifySuite(t *testing.T) {
 		t.Fatalf("Wrong number of suites - %d (expected %d)", len(suites), expected)
 	}
 }
+
+func Test_parseOutputWithoutSummary(t *testing.T) {
+	filename := "data/gotest-nosummary.out"
+	suites, err := loadGotest(filename, t)
+	if err != nil {
+		t.Fatalf("error loading %s - %s", filename, err)
+	}
+	numSuites := 1
+	if len(suites) != numSuites {
+		t.Errorf("got %d suites instead of %d", len(suites), numSuites)
+	}
+
+	suiteName := ""
+	if suites[0].Name != suiteName {
+		t.Errorf("bad Suite name %s, expected %s", suites[0].Name, suiteName)
+	}
+
+	expectedTests := 2
+	actualTests := len(suites[0].Tests)
+	if actualTests != expectedTests {
+		t.Errorf("got %d tests, expected %d", actualTests, expectedTests)
+		for _, st := range suites[0].Tests {
+			t.Log(st.Name)
+		}
+	}
+}

--- a/go2xunit_test.go
+++ b/go2xunit_test.go
@@ -30,7 +30,7 @@ func loadGotest(filename string, t *testing.T) ([]*Suite, error) {
 		t.Fatalf("can't open %s - %s", filename, err)
 	}
 
-	return gtParse(file)
+	return gtParse(file, "")
 }
 
 func Test_parseOutput16(t *testing.T) {
@@ -305,7 +305,7 @@ func Test_parseGocheckPass(t *testing.T) {
 		t.Fatalf("can't open %s - %s", filename, err)
 	}
 
-	suites, err := gcParse(file)
+	suites, err := gcParse(file, "")
 
 	if err != nil {
 		t.Fatalf("can't parse %s - %s", filename, err)
@@ -339,7 +339,7 @@ func Test_parseGocheckFail(t *testing.T) {
 		t.Fatalf("can't open %s - %s", filename, err)
 	}
 
-	suites, err := gcParse(file)
+	suites, err := gcParse(file, "")
 
 	if err != nil {
 		t.Fatalf("can't parse %s - %s", filename, err)

--- a/io_test.go
+++ b/io_test.go
@@ -42,7 +42,7 @@ var goTestFiles = []string{
 
 func Test_XMLOuptutGoCheckXUnit(t *testing.T) {
 	for _, filename := range goCheckFiles {
-		suites, err := gcParse(getInputData(filename))
+		suites, err := gcParse(getInputData(filename), "")
 		checkError(err)
 		generateAndTestXMLXUnit(t, suites, filename)
 	}
@@ -50,7 +50,7 @@ func Test_XMLOuptutGoCheckXUnit(t *testing.T) {
 
 func Test_XMLOuptutGoCheckXUnitNet(t *testing.T) {
 	for _, filename := range goCheckFiles {
-		suites, err := gcParse(getInputData(filename))
+		suites, err := gcParse(getInputData(filename), "")
 		checkError(err)
 		generateAndTestXMLXUnitNet(t, suites, filename)
 	}
@@ -58,7 +58,7 @@ func Test_XMLOuptutGoCheckXUnitNet(t *testing.T) {
 
 func Test_XMLOuptutGoTestXUnit(t *testing.T) {
 	for _, filename := range goTestFiles {
-		suites, err := gtParse(getInputData(filename))
+		suites, err := gtParse(getInputData(filename), "")
 		checkError(err)
 		generateAndTestXMLXUnit(t, suites, filename)
 	}
@@ -66,7 +66,7 @@ func Test_XMLOuptutGoTestXUnit(t *testing.T) {
 
 func Test_XMLOuptutGoTestXunitNet(t *testing.T) {
 	for _, filename := range goTestFiles {
-		suites, err := gtParse(getInputData(filename))
+		suites, err := gtParse(getInputData(filename), "")
 		checkError(err)
 		generateAndTestXMLXUnitNet(t, suites, filename)
 	}

--- a/parsers.go
+++ b/parsers.go
@@ -328,5 +328,11 @@ func gtParse(rd io.Reader) ([]*Suite, error) {
 		return nil, err
 	}
 
+	// If there were no suite names found, but everything else went OK, return
+	// a generic suite.
+	if len(suites) == 0 && curSuite != nil {
+		suites = append(suites, curSuite)
+	}
+
 	return suites, nil
 }

--- a/parsers.go
+++ b/parsers.go
@@ -334,6 +334,8 @@ func gtParse(rd io.Reader, suitePrefix string) ([]*Suite, error) {
 		if curSuite.Name == "" {
 			curSuite.Name = suitePrefix
 		}
+		// Catch any post-failure messages from the last test
+		appendError()
 		suites = append(suites, curSuite)
 	}
 


### PR DESCRIPTION
Bazel's golang test runner uses the normal golang testing runner, but not the actual `go test` command.  Thus, it doesn't include a final test summary line, and go2xunit wasn't able to parse the output without this tweak.  Since the xml output would normally end up with a blank `name` property in this scenario, I've added a `-suite-name-prefix` commandline option that could be used to supply the missing context.

For what it's worth, my first approach was adding a script wrapper around Bazel's test executions and leaving go2xunit unmodified.  I did get that working, but it ended requiring a fairly gross hack.  Adding these features to go2xunit was delightfully simple in comparison.