### PR TITLE
Fix issue with tests ending with Fatal (without summary)

### DIFF
--- a/data/in/gotest-fatal-nosummary.out
+++ b/data/in/gotest-fatal-nosummary.out
@@ -1,0 +1,3 @@
+=== RUN TestPanic
+fatal error: all goroutines are asleep - deadlock!
+...

--- a/data/out/xunit.net/gotest-fatal-nosummary.out.xml
+++ b/data/out/xunit.net/gotest-fatal-nosummary.out.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly name=""
+          run-date="2016-11-22" run-time="15:27:22"
+          configFile="none"
+          time="0.000"
+          total="1"
+          passed="0"
+          failed="1"
+          skipped="0"
+          environment="n/a"
+          test-framework="golang">
+
+    <class time="" name=""
+  	     total="1"
+  	     passed="0"
+  	     failed="1"
+  	     skipped="0">
+
+        <test name="TestPanic"
+          type="test"
+          method="TestPanic"
+          result="Fail"
+          time="N/A">
+          <failure exception-type="go.error">
+             <message><![CDATA[fatal error: all goroutines are asleep - deadlock!
+...]]></message>
+      	  </failure>
+      	</test>
+
+    </class>
+
+</assembly>

--- a/data/out/xunit/gotest-fatal-nosummary.out.xml
+++ b/data/out/xunit/gotest-fatal-nosummary.out.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+  <testsuite name="" tests="1" errors="0" failures="1" skip="0">
+    <testcase classname="" name="TestPanic" time="N/A">
+
+      <failure type="go.error" message="error">
+        <![CDATA[fatal error: all goroutines are asleep - deadlock!
+...]]>
+      </failure>    </testcase>
+  </testsuite>

--- a/lib/parsers.go
+++ b/lib/parsers.go
@@ -143,7 +143,7 @@ func ParseGocheck(rd io.Reader, suitePrefix string) (Suites, error) {
 			test.Time = tokens[4]
 			test.Status = Token2Status(tokens[1])
 			if test.Status == UnknownStatus {
-				return nil, fmt.Errorf("%d: unknonw status %s", scanner.Line(), tokens[1])
+				return nil, fmt.Errorf("%d: unknown status %s", scanner.Line(), tokens[1])
 			}
 
 			if suite == nil || suite.Name != suiteName {
@@ -305,7 +305,7 @@ func ParseGotest(rd io.Reader, suitePrefix string) (Suites, error) {
 			}
 			curTest.Status = Token2Status(tokens[1])
 			if curTest.Status == UnknownStatus {
-				return nil, fmt.Errorf("%d: unknwon status - %s", scanner.Line(), tokens[1])
+				return nil, fmt.Errorf("%d: unknown status - %s", scanner.Line(), tokens[1])
 			}
 			if Options.FailOnRace && hasDatarace(out) {
 				curTest.Status = Failed
@@ -343,6 +343,11 @@ func ParseGotest(rd io.Reader, suitePrefix string) (Suites, error) {
 
 	if err := scanner.Err(); err != nil {
 		return nil, err
+	}
+
+	if curTest != nil {
+		// This occurs when the last test fatal'd outside of the `go test` runner.
+		handlePanic()
 	}
 
 	// If there were no suites found, but everything else went OK, return a


### PR DESCRIPTION
This can trigger when tests terminate with `log.Fatal` or `os.Exit`.

This is an issue report in the form of a PR - currently this kind of failure results in nothing reported from go2xunit :(

@tebeka cc @jordanlewis @raduberinde (ccing because maybe we want to change our log.Fatal to panic at the end instead of os.Exit'ing).