### PR TITLE
allow negative test durations

### DIFF
--- a/lib/parsers.go
+++ b/lib/parsers.go
@@ -18,11 +18,11 @@ const (
 	// --- PASS: TestSub (0.00 seconds)
 	// --- FAIL: TestSubFail (0.00 seconds)
 	// --- SKIP: TestSubSkip (0.00 seconds)
-	gtEndRE = "--- (PASS|FAIL|SKIP):[[:space:]]+([a-zA-Z_][^[:space:]]*) \\((\\d+(.\\d+)?)"
+	gtEndRE = "--- (PASS|FAIL|SKIP):[[:space:]]+([a-zA-Z_][^[:space:]]*) \\((-?\\d+(.\\d+)?)"
 
 	// FAIL	_/home/miki/Projects/goroot/src/xunit	0.004s
 	// ok  	_/home/miki/Projects/goroot/src/anotherTest	0.000s
-	gtSuiteRE = "^(ok|FAIL)[ \t]+([^ \t]+)[ \t]+(\\d+.\\d+)"
+	gtSuiteRE = "^(ok|FAIL)[ \t]+([^ \t]+)[ \t]+(-?\\d+.\\d+)"
 
 	// ?       alipay  [no test files]
 	gtNoFilesRE = "^\\?.*\\[no test files\\]$"
@@ -36,11 +36,11 @@ const (
 
 	// PASS: mmath_test.go:16: MySuite.TestAdd	0.000s
 	// FAIL: mmath_test.go:35: MySuite.TestDiv
-	gcEndRE = "(PASS|FAIL|SKIP|PANIC|MISS): [^:]+:[^:]+: ([A-Za-z_][[:word:]]*).([A-Za-z_][[:word:]]*)[[:space:]]?([0-9]+.[0-9]+)?"
+	gcEndRE = "(PASS|FAIL|SKIP|PANIC|MISS): [^:]+:[^:]+: ([A-Za-z_][[:word:]]*).([A-Za-z_][[:word:]]*)[[:space:]]?(-?[0-9]+.[0-9]+)?"
 
 	// FAIL	go2xunit/demo-gocheck	0.008s
 	// ok  	go2xunit/demo-gocheck	0.008s
-	gcSuiteRE = "^(ok|FAIL)[ \t]+([^ \t]+)[ \t]+(\\d+.\\d+)"
+	gcSuiteRE = "^(ok|FAIL)[ \t]+([^ \t]+)[ \t]+(-?\\d+.\\d+)"
 )
 
 var (


### PR DESCRIPTION
If a machine's clock goes backward during a test, the test duration
reported can be negative. We shouldn't fail to parse those.