### PR TITLE
Escape user-provided strings in XML output.

### DIFF
--- a/data/in/gotest-escaped.out
+++ b/data/in/gotest-escaped.out
@@ -1,0 +1,10 @@
+=== RUN   TestEscapedChars
+=== RUN   TestEscapedChars/no_special_chars
+=== RUN   TestEscapedChars/"needs_escape"
+=== RUN   TestEscapedChars/reserved_<chars>
+--- PASS: TestEscapedChars (0.00s)
+    --- PASS: TestEscapedChars/no_special_chars (0.00s)
+    --- PASS: TestEscapedChars/"needs_escape" (0.00s)
+    --- PASS: TestEscapedChars/reserved_<chars> (0.00s)
+PASS
+ok  	_/go/src/github.com/tebeka/go2xunit/data	0.005s

--- a/data/out/xunit.net/gocheck-empty.out.xml
+++ b/data/out/xunit.net/gocheck-empty.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="github.com/tischda/mmath"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit.net/gocheck-fail.out.xml
+++ b/data/out/xunit.net/gocheck-fail.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="MySuite"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit.net/gocheck-panic.out.xml
+++ b/data/out/xunit.net/gocheck-panic.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="MySuite"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit.net/gocheck-pass.out.xml
+++ b/data/out/xunit.net/gocheck-pass.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="MySuite"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit.net/gocheck-setup-miss.out.xml
+++ b/data/out/xunit.net/gocheck-setup-miss.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="FoobarSuite"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit.net/gotest-0.out.xml
+++ b/data/out/xunit.net/gotest-0.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="package"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit.net/gotest-1.5.out.xml
+++ b/data/out/xunit.net/gotest-1.5.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="_/home/miki/Projects/go/src/bitbucket.org/tebeka/go2xunit/demo"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit.net/gotest-1.6.out.xml
+++ b/data/out/xunit.net/gotest-1.6.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="bitbucket.org/tebeka/go2xunit/demo"
           run-date="2016-08-27" run-time="11:18:17"
           configFile="none"

--- a/data/out/xunit.net/gotest-1.7.out.xml
+++ b/data/out/xunit.net/gotest-1.7.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="github.com/tebeka/go2xunit/demo"
           run-date="2016-08-27" run-time="11:18:17"
           configFile="none"

--- a/data/out/xunit.net/gotest-datarace.out.xml
+++ b/data/out/xunit.net/gotest-datarace.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="go2xunit/demo"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit.net/gotest-empty.out.xml
+++ b/data/out/xunit.net/gotest-empty.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="go2xunit/demo"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit.net/gotest-escaped.out.xml
+++ b/data/out/xunit.net/gotest-escaped.out.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<assembly name="controllers"
-          run-date="2015-06-05" run-time="18:34:41"
+<assembly name="_/go/src/github.com/tebeka/go2xunit/data"
+          run-date="2017-03-20" run-time="23:37:45"
           configFile="none"
-          time="0.024"
+          time="0.005"
           total="4"
           passed="4"
           failed="0"
@@ -11,36 +11,36 @@
           environment="n/a"
           test-framework="golang">
 
-    <class time="0.024" name="controllers"
+    <class time="0.005" name="_/go/src/github.com/tebeka/go2xunit/data"
   	     total="4"
   	     passed="4"
   	     failed="0"
   	     skipped="0">
 
-        <test name="TestApp_AssetPath"
+        <test name="TestEscapedChars"
           type="test"
-          method="TestApp_AssetPath"
+          method="TestEscapedChars"
           result="Pass"
           time="0.00">
         </test>
 
-        <test name="TestTrimTransferCeil"
+        <test name="TestEscapedChars/no_special_chars"
           type="test"
-          method="TestTrimTransferCeil"
+          method="TestEscapedChars/no_special_chars"
           result="Pass"
           time="0.00">
         </test>
 
-        <test name="TestStatusDescription"
+        <test name="TestEscapedChars/&#34;needs_escape&#34;"
           type="test"
-          method="TestStatusDescription"
+          method="TestEscapedChars/&#34;needs_escape&#34;"
           result="Pass"
           time="0.00">
         </test>
 
-        <test name="TestCode"
+        <test name="TestEscapedChars/reserved_&lt;chars&gt;"
           type="test"
-          method="TestCode"
+          method="TestEscapedChars/reserved_&lt;chars&gt;"
           result="Pass"
           time="0.00">
         </test>

--- a/data/out/xunit.net/gotest-fail.out.xml
+++ b/data/out/xunit.net/gotest-fail.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="_/home/miki/Projects/goroot/src/xunit"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit.net/gotest-fatal-nosummary.out.xml
+++ b/data/out/xunit.net/gotest-fatal-nosummary.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name=""
           run-date="2016-11-22" run-time="15:27:22"
           configFile="none"

--- a/data/out/xunit.net/gotest-log.out.xml
+++ b/data/out/xunit.net/gotest-log.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="go2xunit/demo"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit.net/gotest-multierror.out.xml
+++ b/data/out/xunit.net/gotest-multierror.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="skeleton"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit.net/gotest-negative-duration.out.xml
+++ b/data/out/xunit.net/gotest-negative-duration.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="go2xunit/demo"
           run-date="2016-11-22" run-time="14:22:47"
           configFile="none"

--- a/data/out/xunit.net/gotest-nofiles.out.xml
+++ b/data/out/xunit.net/gotest-nofiles.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="controllers"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit.net/gotest-nosummary.out.xml
+++ b/data/out/xunit.net/gotest-nosummary.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name=""
           run-date="2016-09-15" run-time="08:09:30"
           configFile="none"

--- a/data/out/xunit.net/gotest-num.out.xml
+++ b/data/out/xunit.net/gotest-num.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="qbox.us/largefile"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit.net/gotest-panic.out.xml
+++ b/data/out/xunit.net/gotest-panic.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="go2xunit/demo"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit.net/gotest-pass.out.xml
+++ b/data/out/xunit.net/gotest-pass.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="go2xunit/demo"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit.net/gotest-print.out.xml
+++ b/data/out/xunit.net/gotest-print.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="_/home/miki/Projects/goroot/src/anotherTest"
           run-date="2016-08-27" run-time="11:18:17"
           configFile="none"

--- a/data/out/xunit.net/gotest-testify-suite.out.xml
+++ b/data/out/xunit.net/gotest-testify-suite.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="testify-suite"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit.net/gotest.out.xml
+++ b/data/out/xunit.net/gotest.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <assembly name="_/home/miki/Projects/goroot/src/anotherTest"
           run-date="2015-06-05" run-time="18:34:41"
           configFile="none"

--- a/data/out/xunit/gocheck-empty.out.xml
+++ b/data/out/xunit/gocheck-empty.out.xml
@@ -1,3 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="github.com/tischda/mmath" tests="0" errors="0" failures="0" skip="0">
   </testsuite>

--- a/data/out/xunit/gocheck-fail.out.xml
+++ b/data/out/xunit/gocheck-fail.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <testsuites>
   <testsuite name="MySuite1" tests="1" errors="0" failures="0" skip="0">
     <testcase classname="MySuite1" name="TestAdd" time="0.000">

--- a/data/out/xunit/gocheck-panic.out.xml
+++ b/data/out/xunit/gocheck-panic.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="MySuite" tests="5" errors="0" failures="2" skip="1">
     <testcase classname="MySuite" name="TestAdd" time="0.001">
 

--- a/data/out/xunit/gocheck-pass.out.xml
+++ b/data/out/xunit/gocheck-pass.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="MySuite" tests="3" errors="0" failures="0" skip="0">
     <testcase classname="MySuite" name="TestAdd" time="0.000">
 

--- a/data/out/xunit/gocheck-setup-miss.out.xml
+++ b/data/out/xunit/gocheck-setup-miss.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="FoobarSuite" tests="3" errors="0" failures="1" skip="2">
     <testcase classname="FoobarSuite" name="SetUpSuite" time="">
 

--- a/data/out/xunit/gotest-0.out.xml
+++ b/data/out/xunit/gotest-0.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="package" tests="2" errors="0" failures="0" skip="0">
     <testcase classname="package" name="ExampleA" time="4.0003">
 

--- a/data/out/xunit/gotest-1.5.out.xml
+++ b/data/out/xunit/gotest-1.5.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="_/home/miki/Projects/go/src/bitbucket.org/tebeka/go2xunit/demo" tests="4" errors="0" failures="1" skip="0">
     <testcase classname="_/home/miki/Projects/go/src/bitbucket.org/tebeka/go2xunit/demo" name="TestAdd" time="0.00">
 

--- a/data/out/xunit/gotest-1.6.out.xml
+++ b/data/out/xunit/gotest-1.6.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="bitbucket.org/tebeka/go2xunit/demo" tests="4" errors="0" failures="1" skip="0">
     <testcase classname="bitbucket.org/tebeka/go2xunit/demo" name="TestAdd" time="0.00">
 

--- a/data/out/xunit/gotest-1.7.out.xml
+++ b/data/out/xunit/gotest-1.7.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="github.com/tebeka/go2xunit/demo" tests="7" errors="0" failures="1" skip="0">
     <testcase classname="github.com/tebeka/go2xunit/demo" name="TestAdd" time="0.00">
 

--- a/data/out/xunit/gotest-datarace.out.xml
+++ b/data/out/xunit/gotest-datarace.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="go2xunit/demo" tests="1" errors="0" failures="0" skip="0">
     <testcase classname="go2xunit/demo" name="TestDataRace" time="0.00">
 

--- a/data/out/xunit/gotest-empty.out.xml
+++ b/data/out/xunit/gotest-empty.out.xml
@@ -1,3 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="go2xunit/demo" tests="0" errors="0" failures="0" skip="0">
   </testsuite>

--- a/data/out/xunit/gotest-escaped.out.xml
+++ b/data/out/xunit/gotest-escaped.out.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+  <testsuite name="_/go/src/github.com/tebeka/go2xunit/data" tests="4" errors="0" failures="0" skip="0">
+    <testcase classname="_/go/src/github.com/tebeka/go2xunit/data" name="TestEscapedChars" time="0.00">
+
+    </testcase>
+    <testcase classname="_/go/src/github.com/tebeka/go2xunit/data" name="TestEscapedChars/no_special_chars" time="0.00">
+
+    </testcase>
+    <testcase classname="_/go/src/github.com/tebeka/go2xunit/data" name="TestEscapedChars/&#34;needs_escape&#34;" time="0.00">
+
+    </testcase>
+    <testcase classname="_/go/src/github.com/tebeka/go2xunit/data" name="TestEscapedChars/reserved_&lt;chars&gt;" time="0.00">
+
+    </testcase>
+  </testsuite>

--- a/data/out/xunit/gotest-fail.out.xml
+++ b/data/out/xunit/gotest-fail.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="_/home/miki/Projects/goroot/src/xunit" tests="4" errors="0" failures="1" skip="0">
     <testcase classname="_/home/miki/Projects/goroot/src/xunit" name="TestAdd" time="0.00">
 

--- a/data/out/xunit/gotest-fatal-nosummary.out.xml
+++ b/data/out/xunit/gotest-fatal-nosummary.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="" tests="1" errors="0" failures="1" skip="0">
     <testcase classname="" name="TestPanic" time="N/A">
 

--- a/data/out/xunit/gotest-log.out.xml
+++ b/data/out/xunit/gotest-log.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="go2xunit/demo" tests="1" errors="0" failures="0" skip="0">
     <testcase classname="go2xunit/demo" name="TestLogOutput" time="0.00">
 

--- a/data/out/xunit/gotest-multi.out.xml
+++ b/data/out/xunit/gotest-multi.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="controllers" tests="4" errors="0" failures="0" skip="0">
     <testcase classname="controllers" name="TestApp_AssetPath" time="0.00">
 

--- a/data/out/xunit/gotest-multierror.out.xml
+++ b/data/out/xunit/gotest-multierror.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="skeleton" tests="2" errors="0" failures="2" skip="0">
     <testcase classname="skeleton" name="TestError1" time="0.00">
 

--- a/data/out/xunit/gotest-negative-duration.out.xml
+++ b/data/out/xunit/gotest-negative-duration.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="go2xunit/demo" tests="1" errors="0" failures="0" skip="0">
     <testcase classname="go2xunit/demo" name="TestAdd" time="-0.01">
 

--- a/data/out/xunit/gotest-nofiles.out.xml
+++ b/data/out/xunit/gotest-nofiles.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="controllers" tests="4" errors="0" failures="0" skip="0">
     <testcase classname="controllers" name="TestApp_AssetPath" time="0.00">
 

--- a/data/out/xunit/gotest-nosummary.out.xml
+++ b/data/out/xunit/gotest-nosummary.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="" tests="2" errors="0" failures="1" skip="0">
     <testcase classname="" name="TestMeaning" time="0.00">
 

--- a/data/out/xunit/gotest-num.out.xml
+++ b/data/out/xunit/gotest-num.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="qbox.us/largefile" tests="1" errors="0" failures="0" skip="0">
     <testcase classname="qbox.us/largefile" name="TestBasic-8" time="0.00">
 

--- a/data/out/xunit/gotest-panic.out.xml
+++ b/data/out/xunit/gotest-panic.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="go2xunit/demo" tests="1" errors="0" failures="1" skip="0">
     <testcase classname="go2xunit/demo" name="TestPanic" time="N/A">
 

--- a/data/out/xunit/gotest-pass.out.xml
+++ b/data/out/xunit/gotest-pass.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
   <testsuite name="go2xunit/demo" tests="3" errors="0" failures="0" skip="0">
     <testcase classname="go2xunit/demo" name="TestAdd" time="0.00">
 

--- a/data/out/xunit/gotest-print.out.xml
+++ b/data/out/xunit/gotest-print.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <testsuites>
   <testsuite name="_/home/miki/Projects/goroot/src/xunit" tests="5" errors="0" failures="1" skip="1">
     <testcase classname="_/home/miki/Projects/goroot/src/xunit" name="TestAdd" time="0.00">

--- a/data/out/xunit/gotest-testify-suite.out.xml
+++ b/data/out/xunit/gotest-testify-suite.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <testsuites>
   <testsuite name="TestSuite" tests="2" errors="0" failures="0" skip="0">
     <testcase classname="TestSuite" name="TestA" time="0.01">

--- a/data/out/xunit/gotest.out.xml
+++ b/data/out/xunit/gotest.out.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <testsuites>
   <testsuite name="_/home/miki/Projects/goroot/src/xunit" tests="5" errors="0" failures="1" skip="1">
     <testcase classname="_/home/miki/Projects/goroot/src/xunit" name="TestAdd" time="0.00">


### PR DESCRIPTION
We have a few test cases in our codebase which have names containing characters that are reserved in XML. Because they are currently not escaped, Jenkins fails to parse the XML output created by go2xunit. An example (not actual names):

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="some/package/name" tests="52" errors="0" failures="0" skip="0">
  <testcase classname="some/package/name" name="TestInvalidXML/<angleBracket" time="0.00">
  </testcase>
</testsuite>
```

This PR provides a small filter method for the template engine that can be used to XML-escape certain parts of the output. I have applied the filter to the values which could contain reserved characters, I hope I got all of them. 