### PR TITLE
Build using current Go release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-    - 1.7
+    - 1.8
     - tip
 script: go test -v
 sudo: false


### PR DESCRIPTION
This updates the Travis build to use the current stable release (1.8) of Go.