### PR TITLE
Use constant string instead of file for lib.TestLineScannerLongLine.

### DIFF
--- a/lib/lex_test.go
+++ b/lib/lex_test.go
@@ -1,7 +1,7 @@
 package lib
 
 import (
-	"os"
+	"bytes"
 	"testing"
 )
 
@@ -9,18 +9,9 @@ const testLog = `{"Packages":[{"Name":"github.standard.com/standard/maestro-aws-
 
 func TestLineScannerLongLine(t *testing.T) {
 	var (
-		r, e = os.Open("test.log")
-		// r  = bytes.NewBufferString(testLog)
+		r  = bytes.NewBufferString(testLog)
 		ls = NewLineScanner(r)
 	)
-	if e != nil {
-		t.Fatal(e)
-	}
-	defer func() {
-		if err := r.Close(); err != nil {
-			t.Errorf("Error closing reader: %s", err)
-		}
-	}()
 
 	for ls.Scan() {
 		token := ls.Text()


### PR DESCRIPTION
Use constant string instead of file for lib.TestLineScannerLongLine.

Verified that this still tests and fixes the original issue of:

    bufio.Scanner: token too long

When extremely long single-line inputs are fed in to the line scanner.

---

Note: This PR is a followup from #51, and obviates the need for the `test.log` file.