### PR TITLE
Feature/sonar generic data format

### DIFF
--- a/cmdline.go
+++ b/cmdline.go
@@ -16,6 +16,7 @@ var args struct {
 	showVersion bool
 	bambooOut   bool
 	xunitnetOut bool
+	sonarGTDOut bool
 	isGocheck   bool
 	suitePrefix string
 }
@@ -28,6 +29,7 @@ func init() {
 	flag.BoolVar(&args.bambooOut, "bamboo", false,
 		"xml compatible with Atlassian's Bamboo")
 	flag.BoolVar(&args.xunitnetOut, "xunitnet", false, "xml compatible with xunit.net")
+	flag.BoolVar(&args.sonarGTDOut, "sonar", false, "xml compatible with Sonar Generic Test Data")
 	flag.BoolVar(&args.isGocheck, "gocheck", false, "parse gocheck output")
 	flag.BoolVar(&lib.Options.FailOnRace, "fail-on-race", false,
 		"mark test as failing if it exposes a data race")

--- a/lib/file_path_parser.go
+++ b/lib/file_path_parser.go
@@ -1,0 +1,48 @@
+package lib
+
+import (
+	"go/build"
+	"io/ioutil"
+	"strings"
+	"path/filepath"
+)
+
+func fileFileForTest(suite *Suite, test *Test, pkg *build.Package, strip string) string {
+	var (
+		testFileContents = make(map[string]string)
+		body []byte
+		testFilePath string
+		contents string
+		err error
+		ok bool
+	)
+	if strip == "" {
+		strip = pkg.SrcRoot + "/"
+	}
+	for _, testFile := range pkg.TestGoFiles {
+		testFilePath = filepath.Join(pkg.Dir, testFile)
+		if contents, ok = testFileContents[testFilePath]; !ok {
+			if body, err = ioutil.ReadFile(testFilePath); err != nil {
+				continue
+			}
+			contents = string(body)
+			testFileContents[testFilePath] = contents
+		}
+		if strings.Contains(contents, test.Name) {
+			return strings.Replace(testFilePath, strip, "", 1)
+		}
+	}
+
+	return suite.Name
+}
+
+func tmplFuncFilePathForTest(suite *Suite, test *Test, strip string) string {
+	var (
+		pkg *build.Package
+		err error
+	)
+	if pkg, err = build.Import(suite.Name, build.Default.GOPATH, build.IgnoreVendor); err != nil {
+		return suite.Name
+	}
+	return fileFileForTest(suite, test, pkg, strip)
+}

--- a/lib/xmlout.go
+++ b/lib/xmlout.go
@@ -66,15 +66,16 @@ const (
 	// SGTDTemplate is XML template for Sonar Generic Test Data style reporting
 	// https://docs.sonarqube.org/display/SONAR/Generic+Test+Data
 	SGTDTemplate string = `<testExecutions version="1">
-{{range $suite := .Suites}}  <file path="{{.Name | escape}}">
-{{range  $test := $suite.Tests}}    <testCase name="{{$test.Name | escape}}" duration="{{$test.Time}}">
+{{range $suite := .Suites}}
+{{range  $test := $suite.Tests}}  <file path="{{testFilePath $suite $test ""}}">
+	<testCase name="{{$test.Name | escape}}" duration="{{$test.Time}}">
 {{if eq $test.Status $.Skipped }}      <skipped message=""> 
 		<![CDATA[{{$test.Message}}]]>
       </skipped>{{end}}
 {{if eq $test.Status $.Failed }}      <failure message="error">
         <![CDATA[{{$test.Message}}]]>
       </failure>{{end}}    </testCase>
-{{end}}  </file>
+</file>{{end}}  
 {{end}}</testExecutions>`
 )
 
@@ -132,6 +133,7 @@ func WriteXML(suites []*Suite, out io.Writer, xmlTemplate string, testTime time.
 	testsResult.calcTotals()
 	t := template.New("test template").Funcs(template.FuncMap{
 		"escape": escapeForXML,
+		"testFilePath": tmplFuncFilePathForTest,
 	})
 
 	t, err := t.Parse(xml.Header + xmlTemplate)

--- a/lib/xmlout.go
+++ b/lib/xmlout.go
@@ -62,6 +62,20 @@ const (
 {{end}}
 </assembly>
 `
+
+	// SGTDTemplate is XML template for Sonar Generic Test Data style reporting
+	// https://docs.sonarqube.org/display/SONAR/Generic+Test+Data
+	SGTDTemplate string = `<testExecutions version="1">
+{{range $suite := .Suites}}  <file path="{{.Name | escape}}">
+{{range  $test := $suite.Tests}}    <testCase name="{{$test.Name | escape}}" duration="{{$test.Time}}">
+{{if eq $test.Status $.Skipped }}      <skipped message=""> 
+		<![CDATA[{{$test.Message}}]]>
+      </skipped>{{end}}
+{{if eq $test.Status $.Failed }}      <failure message="error">
+        <![CDATA[{{$test.Message}}]]>
+      </failure>{{end}}    </testCase>
+{{end}}  </file>
+{{end}}</testExecutions>`
 )
 
 // TestResults is passed to XML template

--- a/main.go
+++ b/main.go
@@ -95,7 +95,9 @@ func main() {
 	}
 
 	xmlTemplate := lib.XUnitTemplate
-	if args.xunitnetOut {
+	if args.sonarGTDOut {
+		xmlTemplate = lib.SGTDTemplate
+	} else if args.xunitnetOut {
 		xmlTemplate = lib.XUnitNetTemplate
 	} else if args.bambooOut || (len(suites) > 1) {
 		xmlTemplate = lib.XMLMultiTemplate


### PR DESCRIPTION
This adds the ability to output in the Sonar Qube Generic Test Data format
https://docs.sonarqube.org/display/SONAR/Generic+Test+Data

I created a new template for the sonar output, and added a template function that allows you to get the test file a test exists in as required by the Generic Test Data format